### PR TITLE
shore delete functionality

### DIFF
--- a/cmd/shore/shore.go
+++ b/cmd/shore/shore.go
@@ -92,6 +92,7 @@ func init() {
 	rootCmd.AddCommand(command.NewRenderCommand(commonDependencies))
 	rootCmd.AddCommand(command.NewDiffCommand(commonDependencies))
 	rootCmd.AddCommand(command.NewSaveCommand(commonDependencies))
+	rootCmd.AddCommand(command.NewDeleteCommand(commonDependencies))
 	rootCmd.AddCommand(command.NewExecCommand(commonDependencies, "exec"))
 	rootCmd.AddCommand(command.NewTestRemoteCommand(commonDependencies))
 	rootCmd.AddCommand(cleanup_command.NewCleanupCommand(commonDependencies))

--- a/integration_tests/delete_test.go
+++ b/integration_tests/delete_test.go
@@ -1,0 +1,98 @@
+package integration_tests
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/Autodesk/shore/pkg/command"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuccessfulDeleteWithConfigFile(t *testing.T) {
+	SetupTest(t, func(t *testing.T, deps *command.Dependencies) {
+		// Given
+		renderConfig := `{"application": "First Application", "pipeline": "First Pipeline"}`
+
+		afero.WriteFile(deps.Project.FS, path.Join(testPath, "render.json"), []byte(renderConfig), os.ModePerm)
+
+		pipeline := `
+		function(params={})(
+			{
+				application: params.application,
+				name: params.pipeline
+			}
+		)
+		`
+
+		afero.WriteFile(deps.Project.FS, path.Join(testPath, "main.pipeline.jsonnet"), []byte(pipeline), os.ModePerm)
+
+		// Test
+		deleteCmd := command.NewDeleteCommand(deps)
+		deleteCmd.SilenceErrors = true
+		deleteCmd.SilenceUsage = true
+		err := deleteCmd.Execute()
+
+		// Assert
+		assert.Nil(t, err)
+	})
+}
+
+func TestFailedDeleteMissingParam(t *testing.T) {
+	SetupTest(t, func(t *testing.T, deps *command.Dependencies) {
+		// Given
+		expectedErrorMessage := fmt.Sprintf("RUNTIME ERROR: Field does not exist: pipeline\n\t%v/main.pipeline.jsonnet:5:11-26\tobject <anonymous>\n\tField \"name\"\t\n\tDuring manifestation\t\n", testPath)
+
+		renderConfig := `{"application":"Fourth Application"}`
+		afero.WriteFile(deps.Project.FS, path.Join(testPath, "render.json"), []byte(renderConfig), os.ModePerm)
+
+		pipeline := `
+		function(params={})(
+			{
+				application: params.application,
+				name: params.pipeline
+			}
+		)
+		`
+		afero.WriteFile(deps.Project.FS, path.Join(testPath, "main.pipeline.jsonnet"), []byte(pipeline), os.ModePerm)
+
+		// Test
+		deleteCmd := command.NewDeleteCommand(deps)
+		deleteCmd.SilenceErrors = true
+		deleteCmd.SilenceUsage = true
+		err := deleteCmd.Execute()
+
+		// Assert
+		assert.NotNil(t, err)
+		assert.Equal(t, expectedErrorMessage, err.Error())
+	})
+}
+
+func TestSuccessDeleteCommandLineDryRun(t *testing.T) {
+	SetupTest(t, func(t *testing.T, deps *command.Dependencies) {
+		// Given
+		renderConfig := `{"application":"Third Application"}`
+		pipeline := `
+		function(params={})(
+			{
+				application: params.application,
+				name: "Third Pipeline"
+			}
+		)
+		`
+		afero.WriteFile(deps.Project.FS, path.Join(testPath, "main.pipeline.jsonnet"), []byte(pipeline), os.ModePerm)
+
+		// Test
+		deleteCmd := command.NewDeleteCommand(deps)
+		deleteCmd.SilenceErrors = true
+		deleteCmd.SilenceUsage = true
+		deleteCmd.Flags().Set("render-values", renderConfig)
+		deleteCmd.Flags().Set("dry-run", "true")
+		err := deleteCmd.Execute()
+
+		// Assert
+		assert.Nil(t, err)
+	})
+}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -16,4 +16,6 @@ type Backend interface {
 	// TODO: Reconsider `onChange`, it may be a channel to communicate data between `shore-cli` & the Testing process in an async fashion.
 	TestPipeline(testConfig shore_testing.TestsConfig, onChange func(), stringify bool) error
 	GetPipeline(application string, pipelineName string) (map[string]interface{}, *http.Response, error)
+	DeletePipeline(pipelineJSON string) (*http.Response, error)
+	GetPipelinesNamesAndApplication(pipelineJSON string) ([]string, string, error)
 }

--- a/pkg/backend/spinnaker/backend.go
+++ b/pkg/backend/spinnaker/backend.go
@@ -706,8 +706,7 @@ func (s *SpinClient) saveNestedPipeline(stages interface{}, pipeline map[string]
 		if !exists {
 			continue
 		}
-
-		stageTypeField, exists := stage["type"]
+		stageTypeField, exists := stage["type"].(string)
 		if !exists || stageTypeField != "pipeline" {
 			continue
 		}
@@ -886,7 +885,7 @@ func (s *SpinClient) getNestedPipelinesNames(stages interface{}, pipeline map[st
 			continue
 		}
 
-		stageTypeField, exists := stage["type"]
+		stageTypeField, exists := stage["type"].(string)
 		if !exists || stageTypeField != "pipeline" {
 			continue
 		}

--- a/pkg/backend/spinnaker/backend.go
+++ b/pkg/backend/spinnaker/backend.go
@@ -707,6 +707,11 @@ func (s *SpinClient) saveNestedPipeline(stages interface{}, pipeline map[string]
 			continue
 		}
 
+		stageTypeField, exists := stage["type"]
+		if !exists || stageTypeField != "pipeline" {
+			continue
+		}
+
 		switch stagePipelineField.(type) {
 		case string:
 			continue
@@ -878,6 +883,11 @@ func (s *SpinClient) getNestedPipelinesNames(stages interface{}, pipeline map[st
 		stage := stage.(map[string]interface{})
 		stagePipelineField, exists := stage["pipeline"]
 		if !exists {
+			continue
+		}
+
+		stageTypeField, exists := stage["type"]
+		if !exists || stageTypeField != "pipeline" {
 			continue
 		}
 

--- a/pkg/backend/spinnaker/backend.go
+++ b/pkg/backend/spinnaker/backend.go
@@ -945,7 +945,20 @@ func (s *SpinClient) getPipelinesNames(pipeline map[string]interface{}) ([]strin
 	pipelineName := pipeline["name"].(string)
 	pipelineNames = append(pipelineNames, pipelineName)
 
-	return pipelineNames, nil
+	deduplicatedPipelineNames := func(pipelineNames []string) []string {
+		keys := make(map[string]bool)
+		list := []string{}
+
+		for _, entry := range pipelineNames {
+			if _, value := keys[entry]; !value {
+				keys[entry] = true
+				list = append(list, entry)
+			}
+		}
+		return list
+	}(pipelineNames)
+
+	return deduplicatedPipelineNames, nil
 }
 
 // GetPipelinesNamesAndApplication - gets list of names of all pipelines and application name configured

--- a/pkg/backend/spinnaker/backend_mocks.go
+++ b/pkg/backend/spinnaker/backend_mocks.go
@@ -48,6 +48,18 @@ func (p *MockPipelineControllerAPI) SavePipelineUsingPOST(ctx context.Context, p
 	return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
 }
 
+func (p *MockPipelineControllerAPI) DeletePipelineUsingDELETE(ctx context.Context, application string, pipeline string) (*http.Response, error) {
+	data, err := jsoniter.Marshal(pipeline)
+
+	if err != nil {
+		return &http.Response{}, err
+	}
+
+	body := ioutil.NopCloser(bytes.NewReader(data))
+
+	return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+}
+
 func (p *MockPipelineControllerAPI) InvokePipelineConfigUsingPOST1(ctx context.Context, application string, pipelineNameOrID string, localVarOptionals *spinGateApi.PipelineControllerApiInvokePipelineConfigUsingPOST1Opts) (*http.Response, error) {
 	return &http.Response{StatusCode: http.StatusOK}, nil
 }

--- a/pkg/command/delete.go
+++ b/pkg/command/delete.go
@@ -1,0 +1,75 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Autodesk/shore/pkg/config"
+	"github.com/Autodesk/shore/pkg/renderer"
+	"github.com/briandowns/spinner"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// NewDeleteCommand - Using a Project, Renderer & Backend, renders and deletes a pipeline and its nested pipelines.
+// Abstraction for different configuration languages (I.E. Jsonnet/HCL/CUELang)
+func NewDeleteCommand(d *Dependencies) *cobra.Command {
+	var renderVals string
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete the pipeline",
+		Long:  "Using the main file configured by the renderer delete the pipeline (or pipelines)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			settingsBytes, err := config.LoadConfig(d.Project, renderVals, "render")
+
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+
+			pipeline, err := Render(d, settingsBytes, renderer.MainFileName)
+
+			if err != nil {
+				return err
+			}
+
+			if dryRun {
+				pipelineNames, application, err := d.Backend.GetPipelinesNamesAndApplication(pipeline)
+
+				if err != nil {
+					d.Logger.Error("could not get pipelines names and application from the configuration")
+					return err
+				}
+
+				color.Yellow(fmt.Sprintf("Application: %s", application))
+				color.Yellow(fmt.Sprintf("Pipelines to delete: %s", pipelineNames))
+				d.Logger.Info("Backend.GetPipelinesNamesAndApplication returned")
+				return nil
+			}
+
+			s := spinner.New(spinner.CharSets[9], 50*time.Millisecond)
+			s.Writer = color.Error
+			s.Prefix = "Deleting spinnaker pipelines, please wait... "
+			s.Start()
+			res, err := d.Backend.DeletePipeline(pipeline)
+			s.Stop()
+
+			if err != nil {
+				d.Logger.Warnf("Delete pipeline returned an error: %v", err)
+				return err
+			}
+
+			d.Logger.Info("Backend.DeletePipeline returned")
+			fmt.Println(res)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&renderVals, "render-values", "r", "", "A JSON string for the render. If not provided the render.[json/yml/yaml] file is used.")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "list pipelines to be deleted - dry run")
+
+	return cmd
+}


### PR DESCRIPTION
# Overview
 Implementing D from CRUD operations on pipelines with shore.

**Github Issue**: #36 

## Summary (required always)
`shore  delete [-d | --dry-run]` - command renders the pipeline, and deletes the pipeline and it nested pipelines in the same application if they present.
ATM exposing the following APIS in the `Backend` interface :
* `DeletePipeline` - deletes the pipelines asynchronously
* `GetPipelinesNamesAndApplication` - gets all the pipelines rendered and the application they belong to (was exposed in backend because of dry-run being exclusively CLI feature (in my opinion). Making dry-run an option for the `DeletePipeline` function makes the code ugly 🙁.
___
Also publicly available apis in spinnaker backend: 
* `DeletePipelines` - asynchronously deletes pipelines list from the application provided as input.  Writes results to ch. Error encountered is written to errCh and waits till all running in parallel deletion goroutines finish.

## Notes
<!--- Any additional notes for the reviewer/team -->

## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My pull request title follows the format `<username>/<gh-issue-#number>:<short-description>`
- [ ] My code passes existing unit tests
- [ ] My code follows the code style set for the project
- [ ] I have added at least one reviewer for this PR
