### PR TITLE
dkirillov/gh-26: Rendered and Executor determined by the shore config

### DIFF
--- a/cmd/shore/shore.go
+++ b/cmd/shore/shore.go
@@ -29,22 +29,25 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Version:       version,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		logLevel := logrus.WarnLevel + logrus.Level(logVerbosity)
 		logger.SetLevel(logLevel)
 		logger.SetFormatter(&logrus.TextFormatter{})
 
 		if cmd.Name() == "help" {
-			return // No need to do anything, just printing help
+			return nil // No need to do anything, just printing help
 		}
 
-		commonDependencies.Load()
+		if err := commonDependencies.Load(); err != nil {
+			return err
+		}
 
 		profileName := GetProfileName(cmd)
 		ExecConfigName := GetExecutorConfigName(cmd)
 
 		logger.Debug("Profile set to - ", profileName)
 		logger.Debug("Executor configuration set to - ", ExecConfigName)
+		return nil
 	},
 }
 

--- a/cmd/shore/shore.go
+++ b/cmd/shore/shore.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Autodesk/shore/pkg/backend/spinnaker"
 	"github.com/Autodesk/shore/pkg/cleanup_command"
 	"github.com/Autodesk/shore/pkg/command"
 	"github.com/Autodesk/shore/pkg/project"
-	"github.com/Autodesk/shore/pkg/renderer/jsonnet"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -73,11 +71,10 @@ func init() {
 	fs := afero.NewOsFs()
 	logger = logrus.New()
 
-	commonDependencies := &command.Dependencies{
-		Project:  project.NewShoreProject(fs, logger),
-		Renderer: jsonnet.NewRenderer(fs, logger),
-		Backend:  spinnaker.NewClient(logger),
-		Logger:   logger,
+	commonDependencies, err := command.NewDependencies(project.NewShoreProject(fs, logger))
+	if err != nil {
+		logger.Error(err)
+		os.Exit(1)
 	}
 
 	rootCmd.PersistentFlags().CountVarP(&logVerbosity, "verbose", "v", "Logging verbosity")

--- a/cmd/shore/shore.go
+++ b/cmd/shore/shore.go
@@ -71,6 +71,13 @@ func init() {
 	fs := afero.NewOsFs()
 	logger = logrus.New()
 
+	// TODO - Think about loading dependencies in PersistentPreRun
+	// Because NewDependencies calls on LoadShoreConfig which looks for render/exec/e2e YAML
+	// it will fail outside of a shore project - even if the user just tries to do
+	// `shore help`. If it's done in PersistentPreRun, then `shore help` can pass while the
+	// other commands can fail appropriatly - since they do need configs.
+	// This also means that we won't know which renderer/backend is used until just before
+	// it is ran.
 	commonDependencies, err := command.NewDependencies(project.NewShoreProject(fs, logger))
 	if err != nil {
 		logger.Error(err)

--- a/pkg/command/dependencies.go
+++ b/pkg/command/dependencies.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Autodesk/shore/pkg/backend"
 	"github.com/Autodesk/shore/pkg/backend/spinnaker"
@@ -44,7 +45,7 @@ func (d *Dependencies) Load() error {
 	}
 
 	// Select the Renderer
-	switch shoreConfig.Renderer[`type`] {
+	switch strings.ToLower(shoreConfig.Renderer[`type`].(string)) {
 	case JSONNET:
 		d.Logger.Debug("Using the Jsonnet Renderer")
 		chosenRenderer = jsonnet.NewRenderer(d.Project.FS, d.Project.Log)
@@ -54,7 +55,7 @@ func (d *Dependencies) Load() error {
 	d.Renderer = chosenRenderer
 
 	// Select the Backend
-	switch shoreConfig.Executor[`type`] {
+	switch strings.ToLower(shoreConfig.Executor[`type`].(string)) {
 	case SPINNAKER:
 		d.Logger.Debug("Using the Spinnaker Backend")
 		chosenBackend = spinnaker.NewClient(d.Project.Log)

--- a/pkg/command/dependencies.go
+++ b/pkg/command/dependencies.go
@@ -60,7 +60,7 @@ func (d *Dependencies) Load() error {
 		d.Logger.Debug("Using the Spinnaker Backend")
 		chosenBackend = spinnaker.NewClient(d.Project.Log)
 	default:
-		return fmt.Errorf("the following Backend is undefined: %s", shoreConfig.Executor[`type`].(string))
+		return fmt.Errorf("the following Executor is undefined: %s", shoreConfig.Executor[`type`].(string))
 	}
 	d.Backend = chosenBackend
 

--- a/pkg/command/dependencies.go
+++ b/pkg/command/dependencies.go
@@ -26,10 +26,11 @@ const (
 
 // Dependencies - Shared dependencies all controller MAY require
 type Dependencies struct {
-	Renderer renderer.Renderer
-	Backend  backend.Backend
-	Logger   logrus.FieldLogger
-	Project  *project.Project
+	Renderer    renderer.Renderer
+	Backend     backend.Backend
+	Logger      logrus.FieldLogger
+	Project     *project.Project
+	ShoreConfig config.ShoreConfig
 }
 
 // NewDependencies - Creates a Dependencies struct.
@@ -61,9 +62,10 @@ func NewDependencies(p *project.Project) (*Dependencies, error) {
 	}
 
 	return &Dependencies{
-		Project:  p,
-		Renderer: chosenRenderer,
-		Backend:  chosenBackend,
-		Logger:   p.Log,
+		Project:     p,
+		Renderer:    chosenRenderer,
+		Backend:     chosenBackend,
+		Logger:      p.Log,
+		ShoreConfig: shoreConfig,
 	}, nil
 }

--- a/pkg/command/dependencies.go
+++ b/pkg/command/dependencies.go
@@ -1,10 +1,27 @@
 package command
 
 import (
+	"fmt"
+
 	"github.com/Autodesk/shore/pkg/backend"
+	"github.com/Autodesk/shore/pkg/backend/spinnaker"
+	"github.com/Autodesk/shore/pkg/config"
 	"github.com/Autodesk/shore/pkg/project"
 	"github.com/Autodesk/shore/pkg/renderer"
+	"github.com/Autodesk/shore/pkg/renderer/jsonnet"
 	"github.com/sirupsen/logrus"
+)
+
+// Renderer Enum
+const (
+	// JSONNET - Jsonnet Renderer
+	JSONNET string = "jsonnet"
+)
+
+// Backend Enum
+const (
+	// SPINNAKER - Spinnaker Backend
+	SPINNAKER string = "spinnaker"
 )
 
 // Dependencies - Shared dependencies all controller MAY require
@@ -13,4 +30,40 @@ type Dependencies struct {
 	Backend  backend.Backend
 	Logger   logrus.FieldLogger
 	Project  *project.Project
+}
+
+// NewDependencies - Creates a Dependencies struct.
+func NewDependencies(p *project.Project) (*Dependencies, error) {
+	var chosenRenderer renderer.Renderer
+	var chosenBackend backend.Backend
+
+	shoreConfig, err := config.LoadShoreConfig(p)
+	if err != nil {
+		return &Dependencies{}, err
+	}
+
+	// Select the Renderer
+	switch shoreConfig.Renderer[`type`] {
+	case JSONNET:
+		p.Log.Debug("Using the Jsonnet Renderer")
+		chosenRenderer = jsonnet.NewRenderer(p.FS, p.Log)
+	default:
+		return &Dependencies{}, fmt.Errorf("the following Renderer is undefined: %s", shoreConfig.Renderer[`type`].(string))
+	}
+
+	// Select the Backend
+	switch shoreConfig.Executor[`type`] {
+	case SPINNAKER:
+		p.Log.Debug("Using the Spinnaker Backend")
+		chosenBackend = spinnaker.NewClient(p.Log)
+	default:
+		return &Dependencies{}, fmt.Errorf("the following Backend is undefined: %s", shoreConfig.Executor[`type`].(string))
+	}
+
+	return &Dependencies{
+		Project:  p,
+		Renderer: chosenRenderer,
+		Backend:  chosenBackend,
+		Logger:   p.Log,
+	}, nil
 }

--- a/pkg/command/dependencies.go
+++ b/pkg/command/dependencies.go
@@ -34,7 +34,7 @@ type Dependencies struct {
 	ShoreConfig config.ShoreConfig
 }
 
-// NewDependencies - Creates a Dependencies struct.
+// Load - loads the shore config and sets the renderer and backend
 func (d *Dependencies) Load() error {
 	var chosenRenderer renderer.Renderer
 	var chosenBackend backend.Backend

--- a/pkg/command/dependencies_test.go
+++ b/pkg/command/dependencies_test.go
@@ -108,7 +108,7 @@ func TestFailingLoad(t *testing.T) {
 			name:               "wrong-backend",
 			configuredBackend:  "yolo",
 			configuredRenderer: "jsonnet",
-			expectedError:      "Backend is undefined",
+			expectedError:      "Executor is undefined",
 		},
 		{
 			name:               "wrong-renderer",

--- a/pkg/command/dependencies_test.go
+++ b/pkg/command/dependencies_test.go
@@ -1,0 +1,130 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/Autodesk/shore/pkg/backend/spinnaker"
+	"github.com/Autodesk/shore/pkg/project"
+	"github.com/Autodesk/shore/pkg/renderer/jsonnet"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+var testPath = "/test"
+var shoreConfigTemplate = `{
+	"renderer": {
+		"type": "%s"
+	},
+	"executor": {
+		"type": "%s",
+		"config": {
+		"default": "~/.spin/sb-config",
+		"prodSpin": "~/.spin/prod-config"
+		}
+	},
+	"profiles": {
+		"default": {
+		"application": "test1test2test3",
+		"pipeline": "simple-pipeline-test",
+		"render": "render.yaml",
+		"exec": "exec.yaml",
+		"e2e": "e2e.yaml"
+		}
+	}
+}`
+
+func SetupTestProject() *project.Project {
+	os.Setenv("LOCAL", "true")
+	os.Setenv("SHORE_PROJECT_PATH", testPath)
+
+	memFs := afero.NewMemMapFs()
+	memFs.Mkdir(testPath, os.ModePerm)
+
+	logger, _ := test.NewNullLogger()
+
+	return project.NewShoreProject(memFs, logger)
+}
+
+func TestPassingNewDependencies(t *testing.T) {
+	// Given
+	proj := SetupTestProject()
+
+	tests := []struct {
+		name               string
+		configuredBackend  string
+		configuredRenderer string
+		expectedBackend    interface{}
+		expectedRenderer   interface{}
+	}{
+		{
+			name:               "spinnaker/jsonnet",
+			configuredBackend:  "spinnaker",
+			configuredRenderer: "jsonnet",
+			expectedBackend:    &spinnaker.SpinClient{},
+			expectedRenderer:   &jsonnet.Jsonnet{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			shoreConfig := fmt.Sprintf(shoreConfigTemplate, test.configuredRenderer, test.configuredBackend)
+			afero.WriteFile(proj.FS, path.Join(testPath, "shore.json"), []byte(shoreConfig), os.ModePerm)
+
+			// When
+			deps, err := NewDependencies(proj)
+
+			// Then
+			assert.NoError(t, err)
+			assert.IsType(t, test.expectedRenderer, deps.Renderer)
+			assert.IsType(t, test.expectedBackend, deps.Backend)
+		})
+	}
+}
+
+func TestFailingNewDependencies(t *testing.T) {
+	// Given
+	proj := SetupTestProject()
+
+	tests := []struct {
+		name               string
+		configuredBackend  string
+		configuredRenderer string
+		expectedError      string
+	}{
+		{
+			name:               "wrong-backend",
+			configuredBackend:  "yolo",
+			configuredRenderer: "jsonnet",
+			expectedError:      "Backend is undefined",
+		},
+		{
+			name:               "wrong-renderer",
+			configuredBackend:  "spinnaker",
+			configuredRenderer: "yolo",
+			expectedError:      "Renderer is undefined",
+		},
+		{
+			name:               "malformed-config",
+			configuredBackend:  "\"",
+			configuredRenderer: "yolo",
+			expectedError:      "object not ended with",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			shoreConfig := fmt.Sprintf(shoreConfigTemplate, test.configuredRenderer, test.configuredBackend)
+			afero.WriteFile(proj.FS, path.Join(testPath, "shore.json"), []byte(shoreConfig), os.ModePerm)
+
+			// When
+			deps, err := NewDependencies(proj)
+
+			// Then
+			assert.Empty(t, deps)
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, test.expectedError)
+		})
+	}
+}

--- a/pkg/command/dependencies_test.go
+++ b/pkg/command/dependencies_test.go
@@ -70,6 +70,13 @@ func TestPassingLoad(t *testing.T) {
 			expectedBackend:    &spinnaker.SpinClient{},
 			expectedRenderer:   &jsonnet.Jsonnet{},
 		},
+		{
+			name:               "insensetive-spinnaker/jsonnet",
+			configuredBackend:  "sPiNnAkEr",
+			configuredRenderer: "JsOnNeT",
+			expectedBackend:    &spinnaker.SpinClient{},
+			expectedRenderer:   &jsonnet.Jsonnet{},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/command/dependencies_test.go
+++ b/pkg/command/dependencies_test.go
@@ -1,17 +1,11 @@
 package command
 
 import (
-	"fmt"
 	"os"
-	"path"
-	"testing"
 
-	"github.com/Autodesk/shore/pkg/backend/spinnaker"
 	"github.com/Autodesk/shore/pkg/project"
-	"github.com/Autodesk/shore/pkg/renderer/jsonnet"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 )
 
 var testPath = "/test"
@@ -49,7 +43,7 @@ func SetupTestProject() *project.Project {
 	return project.NewShoreProject(memFs, logger)
 }
 
-func TestPassingNewDependencies(t *testing.T) {
+/*func TestPassingNewDependencies(t *testing.T) {
 	// Given
 	proj := SetupTestProject()
 
@@ -127,4 +121,4 @@ func TestFailingNewDependencies(t *testing.T) {
 			assert.ErrorContains(t, err, test.expectedError)
 		})
 	}
-}
+}*/


### PR DESCRIPTION
# Overview

**Github Issue**: #26 

## Summary (required always)

This PR makes use of the new shore config, by loading it and using it to determine the type of renderer and executor to use.

(Functionality of `LoadShoreConfig` introduced in https://github.com/Autodesk/shore/commit/7c38b57573617ba74027bb71ae1729e52db6e84d)
Done on a project that has a shore config, it will load it and use the types defined for the renderer and executor.
When a project does not have a shore config, it will drop a default one.

## Notes

<details>
<summary>Unit tests pass</summary>

![Screenshot 2023-04-05 at 3 55 24 PM](https://user-images.githubusercontent.com/1696313/230193062-bfb9c09a-b8ab-4f68-a79b-c3d9811dbd10.png)

</details>


<details>
<summary>To test, installed a local version from branch's source</summary>

![Screenshot 2023-04-05 at 3 08 08 PM](https://user-images.githubusercontent.com/1696313/230194472-705c0dd6-0a70-42ce-968d-10775c1a92fc.png)

</details>

`shore help` requires no configuration and should always work, so it was tested.

<details>
<summary><code>shore help</code> - outside a shore project - should work</summary>

![Screenshot 2023-04-05 at 3 12 17 PM](https://user-images.githubusercontent.com/1696313/230194805-42f65dd3-bb3d-4812-990b-8c27e4353d1b.png)

</details>

<details>
<summary><code>shore help</code> - inside a shore project - should work</summary>

![Screenshot 2023-04-05 at 4 03 21 PM](https://user-images.githubusercontent.com/1696313/230195888-aaf09436-1309-460c-b9e8-8028336211a7.png)

</details>

`shore render` and `shore save` were picked and tested because `render` relies on the renderer type being set, and `save` relies on the renderer type and the executor type being set.

<details>
<summary><code>shore render</code> - outside a shore project - shouldn't work</summary>

![Screenshot 2023-04-05 at 3 11 16 PM](https://user-images.githubusercontent.com/1696313/230195093-c5336a23-0bff-40ed-8852-3cb21910107b.png)

</details>

<details>
<summary><code>shore render</code> - inside a shore project - should work - also drops a new shore config</summary>

![Screenshot 2023-04-05 at 3 14 02 PM](https://user-images.githubusercontent.com/1696313/230195196-fc0b9a1d-b36c-48bc-91f8-505cf2fd3902.png)
![Screenshot 2023-04-05 at 3 14 09 PM](https://user-images.githubusercontent.com/1696313/230195241-f9b8139a-4afc-4e8e-9ea3-f18f397f7cf7.png)

This was the first time that this was ran in this shore project, so a shore config was created.

</details>

<details>
<summary><code>shore save</code> - outside a shore project - shouldn't work</summary>

![Screenshot 2023-04-05 at 3 11 39 PM](https://user-images.githubusercontent.com/1696313/230195352-6a2bb4a6-79c0-4762-bf41-ad6b4874e333.png)

</details>

<details>
<summary><code>shore save</code> - inside a shore project - should work - also loads an existing shore config</summary>

![Screenshot 2023-04-05 at 3 15 50 PM](https://user-images.githubusercontent.com/1696313/230195436-644955d6-0c9a-4f44-9748-9c51a3fb76f0.png)

This was ran after `shore render`, and so the shore config was already there and was loaded and used.

</details>

<details>
<summary><code>shore render</code> - inside a shore project, bad renderer type - shouldn't work</summary>

![Screenshot 2023-04-05 at 3 19 58 PM](https://user-images.githubusercontent.com/1696313/230196033-29efe69d-2169-41d7-83b4-b8e004c5423e.png)

</details>

<details>
<summary><code>shore save</code> - inside a shore project, bad executor type - shouldn't work</summary>

![Screenshot 2023-04-05 at 3 19 19 PM](https://user-images.githubusercontent.com/1696313/230196114-a1ec3b00-92a3-4cf3-a531-c01a2f4ec99b.png)

</details>

## Checklist
- [x] My pull request title follows the format `<username>/<gh-issue-#number>:<short-description>`
- [x] My code passes existing unit tests
- [x] My code follows the code style set for the project
- [x] I have added at least one reviewer for this PR
