### PR TITLE
dkirillov/gh-76: Diff command - LoadConfig arg fix

### DIFF
--- a/pkg/command/diff.go
+++ b/pkg/command/diff.go
@@ -26,7 +26,7 @@ func NewDiffCommand(d *Dependencies) *cobra.Command {
 		Long:  `Shows difference between current and desired state of the pipeline.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			settingsBytes, err := config.LoadConfig(d.Project, "render", renderValues)
+			settingsBytes, err := config.LoadConfig(d.Project, renderValues, "render")
 
 			var confErr *config.ConfigurationErr
 


### PR DESCRIPTION
# Overview

**Github Issue**: #76

## Summary (required always)
This PR fixes diff command's use of `LoadConfig` by providing the arguments in proper order.

## Notes
Built and tested locally:
<details>
<summary>screenshots</summary>

![Screenshot 2023-05-04 at 12 47 59 PM](https://user-images.githubusercontent.com/1696313/236276515-9ffa67ce-cb63-4142-b415-b219c2b9e974.png)
![Screenshot 2023-05-04 at 1 04 28 PM](https://user-images.githubusercontent.com/1696313/236276545-55399624-9827-40ed-847f-7e318ae95e10.png)
![Screenshot 2023-05-04 at 1 06 42 PM](https://user-images.githubusercontent.com/1696313/236276553-e9fc1e1f-96a2-4ebe-853b-9c636ba6aa9d.png)

</details>

Unit tests pass:
<details>
<summary>screenshot</summary>

![Screenshot 2023-05-04 at 1 11 09 PM](https://user-images.githubusercontent.com/1696313/236276827-402d63ae-4216-4306-8963-9c945b6dc1f9.png)

</details>

## Checklist
- [x] My pull request title follows the format `<username>/<gh-issue-#number>:<short-description>`
- [x] My code passes existing unit tests
- [x] My code follows the code style set for the project
- [x] I have added at least one reviewer for this PR
