### PR TITLE
fix deprecated property

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,8 @@ builds:
 archives:
   - id: shore
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .ProjectName -}}_
+      {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,11 +14,13 @@ builds:
       - darwin
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
+  - id: shore
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
# Overview

**Github Issue**: #82 

`goreleaser` [have deprecated](https://goreleaser.com/deprecations/#archivesreplacements) `archives.replacements` property and failed releasing `v0.0.12` shore-delete

## Summary (required always)
<!--- Summarize your changes in detail -->

## Notes
<!--- Any additional notes for the reviewer/team -->

## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My pull request title follows the format `<username>/<gh-issue-#number>:<short-description>`
- [ ] My code passes existing unit tests
- [ ] My code follows the code style set for the project
- [ ] I have added at least one reviewer for this PR
