### PR TITLE
milindcq/gh-84: pipelineID resolution fix for multi/mixed pipeline stages

### DIFF
--- a/pkg/backend/spinnaker/backend.go
+++ b/pkg/backend/spinnaker/backend.go
@@ -748,7 +748,7 @@ func (s *SpinClient) saveNestedPipeline(stages interface{}, pipeline map[string]
 			for _, stage := range childPipelineStages.([]interface{}) {
 				innerStage := stage.(map[string]interface{})
 
-				if !hasChildPipelines && mapContainsKey(innerStage, "application") && mapContainsKey(innerStage, "pipeline") && reflect.TypeOf(innerStage["pipeline"]).Kind() == reflect.String {
+				if mapContainsKey(innerStage, "application") && mapContainsKey(innerStage, "pipeline") && reflect.TypeOf(innerStage["pipeline"]).Kind() == reflect.String {
 					if response, result := s.findAndReplacePipelineNameWithFoundID(innerStage); response {
 						stage = result
 					}

--- a/pkg/backend/spinnaker/backend.go
+++ b/pkg/backend/spinnaker/backend.go
@@ -249,12 +249,12 @@ func (s *SpinClient) savePipeline(pipelineJSON string) (string, *http.Response, 
 			return pipelineID, nil, wrappedErr
 		}
 
-		s.log.Info("Pipeline %q not found in application %q", pipelineName, application)
+		s.log.Infof("Pipeline %q not found in application %q", pipelineName, application)
 	}
 
 	// pipeline found, let's use Spinnaker's known Pipeline ID, otherwise we'll get one created for us
 	if len(foundPipeline) > 0 {
-		s.log.Info("Pipeline %q found with ID %q", foundPipeline["name"], foundPipeline["id"], application)
+		s.log.Infof("Pipeline %q found with ID %q in application %q", foundPipeline["name"], foundPipeline["id"], application)
 
 		pipeline["id"] = foundPipeline["id"].(string)
 		pipelineID = foundPipeline["id"].(string)

--- a/pkg/backend/spinnaker/backend_mocks.go
+++ b/pkg/backend/spinnaker/backend_mocks.go
@@ -29,7 +29,8 @@ func (a *MockApplicationControllerAPI) GetPipelineConfigUsingGET(ctx context.Con
 		res = map[string]interface{}{}
 	} else {
 		res = map[string]interface{}{
-			"id": "1234",
+			"name": pipelineName,
+			"id":   "1234",
 		}
 	}
 


### PR DESCRIPTION
# Overview

**Github Issue**: https://github.com/Autodesk/shore/issues/84


## Summary (required always)
While rendering a nested pipeline If one of the pipeline stage is a nested pipeline and another refers to an existing pipeline. The spinnaker pipeline id for the existing pipeline stage is not resolved. This is due to faulty check that skips the id resolution due to this check (https://github.com/Autodesk/shore/blob/567fcf51dd852d6449986a5de009e8dbebf09c8f/pkg/backend/spinnaker/backend.go#L751))


## Notes
Unit-tests result:

[unit-test-results.txt](https://github.com/Autodesk/shore/files/12315648/unit-test-results.txt)

Before (failed pipeline id resolution):
<img width="343" alt="Screenshot 2023-08-10 at 10 25 24 AM" src="https://github.com/Autodesk/shore/assets/1829255/9e994aca-4225-4742-b354-cb8cc127ad2b">


After the PR the pipeline ID was resolved successfully:
<img width="423" alt="Screenshot 2023-08-10 at 10 30 10 AM" src="https://github.com/Autodesk/shore/assets/1829255/0d4674f7-e0c4-4d02-8393-607ce7f377ab">


## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request title follows the format `<username>/<gh-issue-#number>:<short-description>`
- [x] My code passes existing unit tests
- [x] My code follows the code style set for the project
- [x] I have added at least one reviewer for this PR